### PR TITLE
[WIP] Bump Rubyzip requirement to >= 2.4 to allow 3.0

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby-version: ['3.3']
+        ruby-version: ['3.4']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           - ruby: 3.1
           - ruby: 3.2
           - ruby: 3.3
+          - ruby: 3.4
           - ruby: jruby-9.3
           - ruby: jruby-9.4
           - ruby: head

--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby-version: ['3.3']
+        ruby-version: ['3.4']
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 CHANGELOG
 ---------
 - **Unreleased**
+  - [PR #421](https://github.com/caxlsx/caxlsx/pull/421) Add Rubyzip >= 2.4 support
 
 - **December.15.24**: 4.2.0
   - [PR #359](https://github.com/caxlsx/caxlsx/pull/359) Add `PivotTable#grand_totals` option to remove grand totals row/col

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 CHANGELOG
 ---------
 - **Unreleased**
+
+- **December.15.24**: 4.2.0
   - [PR #359](https://github.com/caxlsx/caxlsx/pull/359) Add `PivotTable#grand_totals` option to remove grand totals row/col
   - [PR #362](https://github.com/caxlsx/caxlsx/pull/362) Use widest width even if provided as fixed value
   - [PR #398](https://github.com/caxlsx/caxlsx/pull/398) Add `Axlsx#uri_parser` method for RFC2396 compatibility

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development, :test do
   gem 'yard'
 
   if RUBY_VERSION >= '2.7'
-    gem 'rubocop', '1.69.1'
+    gem 'rubocop', '1.69.2'
     gem 'rubocop-minitest', '0.36.0'
     gem 'rubocop-packaging', '0.5.2'
     gem 'rubocop-performance', '1.23.0'

--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "htmlentities", "~> 4.3", '>= 4.3.4'
   s.add_dependency "marcel", '~> 1.0'
   s.add_dependency 'nokogiri', '~> 1.10', '>= 1.10.4'
-  s.add_dependency 'rubyzip', '>= 1.3.0', '< 3'
+  s.add_dependency 'rubyzip', '>= 2.4', '< 4'
 
   s.required_ruby_version = '>= 2.6'
   s.require_path = 'lib'

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -211,7 +211,8 @@ module Axlsx
     # @return [Zip::Entry]
     def zip_entry_for_part(part)
       timestamp = Zip::DOSTime.at(@core.created.to_i)
-      Zip::Entry.new("", part[:entry], "", "", 0, 0, Zip::Entry::DEFLATED, 0, timestamp)
+
+      Zip::Entry.new("", part[:entry], time: timestamp)
     end
 
     # The parts of a package

--- a/lib/axlsx/util/buffered_zip_output_stream.rb
+++ b/lib/axlsx/util/buffered_zip_output_stream.rb
@@ -19,7 +19,7 @@ module Axlsx
     #
     # The directory and its contents are removed at the end of the block.
     def self.open(file_name, encrypter = nil)
-      Zip::OutputStream.open(file_name, encrypter) do |zos|
+      Zip::OutputStream.open(file_name, encrypter: encrypter) do |zos|
         bzos = new(zos)
         yield(bzos)
       ensure
@@ -28,7 +28,7 @@ module Axlsx
     end
 
     def self.write_buffer(io = ::StringIO.new, encrypter = nil)
-      Zip::OutputStream.write_buffer(io, encrypter) do |zos|
+      Zip::OutputStream.write_buffer(io, encrypter: encrypter) do |zos|
         bzos = new(zos)
         yield(bzos)
       ensure

--- a/lib/axlsx/version.rb
+++ b/lib/axlsx/version.rb
@@ -2,5 +2,5 @@
 
 module Axlsx
   # The current version
-  VERSION = "4.1.0"
+  VERSION = "4.2.0"
 end


### PR DESCRIPTION
--- WIP: 2.4 is still in RC ---

Since:
- As per Rubyzip's readme, it is not recommended to use any versions of Rubyzip earlier than 2.3 due to security issues
- Rubyzip 2.4 requires Ruby >= 2.4
- Caxlsx requires Ruby >= 2.6

This commit bumps the minimum required Rubyzip version to 2.4 and changes syntax accordingly to allow 3.0 compatibility with the minimum amount of changes to production code

Closes #384
